### PR TITLE
(hotfix): Paypal Disabled causing issues with checkout order button rendering

### DIFF
--- a/view/frontend/web/js/view/billing-address-mixin.js
+++ b/view/frontend/web/js/view/billing-address-mixin.js
@@ -11,7 +11,10 @@ define([
 
             var paymentMethod = quote.paymentMethod();
 
-            if (paymentMethod && this.dataScopePrefix.includes(paymentMethod.method)) {
+            if (paymentMethod &&
+                typeof this.dataScopePrefix !== 'undefined' &&
+                this.dataScopePrefix.includes(paymentMethod.method)
+            ) {
                 quote.billingAddress.subscribe(function (newAddress) {
                     if (isExpressPayment() && quote.isVirtual()) {
                         checkoutDataHelper.setRvvupBillingAddress(newAddress);

--- a/view/frontend/web/js/view/payment/method-renderer/rvvup-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/rvvup-method.js
@@ -502,6 +502,13 @@ define([
             },
             getPayLaterConfigValue: function (key) {
                 let values = rvvup_parameters
+
+                const paypalLoaded = !!values?.settings?.paypal?.checkout;
+
+                if (!paypalLoaded) {
+                    return false;
+                }
+
                 if (['enabled', 'textSize'].includes(key)) {
                     return values.settings.paypal.checkout.payLaterMessaging[key]
                 }


### PR DESCRIPTION
If PayPal is disabled via the Rvvup portal, checkout payment methods templates are broken due to checking undefined js object properties.

- Perform null checking when loading js object properties & return false if non-exist.
- Fix mixin failing if dataScopePrefix is undefined (error occurs if you click back to shipping step from payment step)