### PR TITLE
Added graphql schema to fetch payment enabled/disabled from config

### DIFF
--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\StoreGraphQl\Model\Resolver\Store\StoreConfigDataProvider">
+        <arguments>
+            <argument name="extendedConfigData" xsi:type="array">
+                <item name="rvvup_payments_active" xsi:type="string">payment/rvvup/active</item>
+            </argument>
+        </arguments>
+    </type>
+</config>

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,0 +1,3 @@
+type StoreConfig {
+    rvvup_payments_active: String @doc(description: "Rvvup Payments Active")
+}


### PR DESCRIPTION
Follows documentation on: https://developer.adobe.com/commerce/webapi/graphql/develop/extend-existing-schema/#extend-configuration-data

- Querying core Magento GraphQL for `rvvup_payments_active` store config

![image](https://github.com/rvvup/magento-plugin/assets/84732055/de36fc09-642f-41fb-9dd5-7787d13ca85f)


![Screenshot 2023-05-30 at 16 42 34](https://github.com/rvvup/magento-plugin/assets/84732055/ff70c161-fe90-4f45-a213-e2f7ec923ff4)


- Result returns `0` for disabled, `1` for enabled


![Screenshot 2023-05-30 at 16 31 24](https://github.com/rvvup/magento-plugin/assets/84732055/dce72144-db20-470f-8db9-468f08088d73)


![Screenshot 2023-05-30 at 16 39 57](https://github.com/rvvup/magento-plugin/assets/84732055/ea1fe518-999e-4e27-8e07-6dc6065e6dcb)

