### PR TITLE
TSA-713: Added missing parameter to clear cache call

### DIFF
--- a/Gateway/Command/Refund.php
+++ b/Gateway/Command/Refund.php
@@ -76,6 +76,7 @@ class Refund implements CommandInterface
 
         $order = $payment->getOrder();
         $rvvupOrderId = $payment->getAdditionalInformation('rvvup_order_id');
+        $orderState = $payment->getOrder()->getState();
 
         $input = $this->refundCreateInputFactory->create(
             $rvvupOrderId,
@@ -86,7 +87,7 @@ class Refund implements CommandInterface
         );
 
         $result = $this->sdkProxy->refundCreate($input);
-        $this->cache->clear($rvvupOrderId);
+        $this->cache->clear($rvvupOrderId, $orderState);
         $refundId = $result['id'];
         $refundStatus = $result['status'];
 


### PR DESCRIPTION
Address errors arising when `clear()` cache call is made without the required parameters. See `system.log` file in Jira ticket for more details: https://rvvup.atlassian.net/browse/TSA-713