### PR TITLE
Bugfix: Force order id to be a string

### DIFF
--- a/Controller/Redirect/In.php
+++ b/Controller/Redirect/In.php
@@ -132,7 +132,7 @@ class In implements HttpGetActionInterface
             $this->checkoutSession->setLastQuoteId($quote->getId());
             $this->checkoutSession->setLastOrderId($quote->getReservedOrderId());
             $this->checkoutSession->setLastRealOrderId($quote->getReservedOrderId());
-            return $this->captureService->processOrderResult($orderId, $rvvupId, true);
+            return $this->captureService->processOrderResult((string)$orderId, $rvvupId, true);
         }
 
         if (!$orderId) {
@@ -156,7 +156,7 @@ class In implements HttpGetActionInterface
             return $this->redirectToCart();
         }
 
-        return $this->captureService->processOrderResult($orderId, $rvvupId);
+        return $this->captureService->processOrderResult((string)$orderId, $rvvupId);
     }
 
     /**


### PR DESCRIPTION
I'm getting this error:
```
TypeError: Rvvup\Payments\Service\Capture::processOrderResult(): Argument #1 ($orderId) must be of type ?string, int given, called in /var/www/html/vendor/rvvup/module-magento-payments/Controller/Redirect/In.php on line 159 and defined in /var/www/html/vendor/rvvup/module-magento-payments/Service/Capture.php:374
```

This PR fixes this issue.