### PR TITLE
fix issue where input border is cut or half hidden

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/rvvup-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/rvvup-method.js
@@ -259,6 +259,9 @@ define([
                             "font-size-label": "1.2rem",
                             "font-size-message": "1rem",
                             "space-outset-message": "0rem 0px 0px 0.5rem",
+                            // a few browser engines round up the iframe context window, making it cut off the border.
+                            // Giving it a padding helps to prevent this.
+                            "space-inset-body": "0 1px 0 0",
                         },
                     });
                     window.SecureTrading.Components();


### PR DESCRIPTION
A few browsers have as its behaviour to round its size when passing relative sizes (e.g. 100%) so if the iframe itself fits a container or have a width with decimal case (e.g. 350.55px), the iframe inner content will have a width of 351px, where in our case it endup cutting the border at right.

This fix prevents that from happening by taking 1px of the input and adding as padding so it have 1px of empty space