### PR TITLE
fix: max-width not respecting checkout iframe resize.

### DIFF
--- a/view/frontend/web/css/source/_module.less
+++ b/view/frontend/web/css/source/_module.less
@@ -8,7 +8,6 @@
     }
     .rvvup {
         .modal-inner-wrap {
-            max-width: 60rem !important;
             left: 0 !important; // overriding modal css
             margin-left: auto !important; // overriding modal css
 


### PR DESCRIPTION
Removing the max-width makes the plugin respect the resize event sent from Rvvup checkout without restrictions.