### PR TITLE
Return Skip Response instead of Not Found in Webhook

### DIFF
--- a/Controller/Webhook/Index.php
+++ b/Controller/Webhook/Index.php
@@ -245,18 +245,6 @@ class Index implements HttpPostActionInterface, CsrfAwareActionInterface
 
     /**
      * @param string $reason
-     * @return ResultInterface
-     */
-    private function returnNotFound(string $reason): ResultInterface
-    {
-        $response = $this->resultFactory->create($this->resultFactory::TYPE_JSON);
-        $response->setHttpResponseCode(404);
-        $response->setData(['reason' => $reason]);
-        return $response;
-    }
-
-    /**
-     * @param string $reason
      * @param array $metadata
      * @return ResultInterface
      */
@@ -378,7 +366,7 @@ class Index implements HttpPostActionInterface, CsrfAwareActionInterface
         } elseif (isset($order)) {
             $payload['magento_order_id'] = $order->getId();
         } else {
-            return $this->returnNotFound('Order/quote not found for ' . $eventType);
+            return $this->returnSkipResponse('Order/quote not found for ' . $eventType, []);
         }
         $this->webhookRepository->addToWebhookQueue($payload);
         return $this->returnSuccessfulResponse();

--- a/Test/Unit/Controller/Webhook/IndexTest.php
+++ b/Test/Unit/Controller/Webhook/IndexTest.php
@@ -176,7 +176,7 @@ class IndexTest extends TestCase
         $this->captureService->method('getQuoteByRvvupId')->willReturn(null);
         $this->captureService->method('getOrderByRvvupId')->willThrowException(new PaymentValidationException(__('Error')));
 
-        $this->expectsResult(404, ['reason' => 'Order/quote not found for ' . $eventType]);
+        $this->expectsResult(210, ['reason' => 'Order/quote not found for ' . $eventType, 'metadata' => []]);
 
         $response = $this->controller->execute();
 


### PR DESCRIPTION
Prevent the webhook from retrying if the order/quote does not exist in our store.