### PR TITLE
Add fix for recaptcha on Magento 2.4.7 or higher

### DIFF
--- a/view/frontend/web/js/action/checkout/payment/get-order-payment-actions.js
+++ b/view/frontend/web/js/action/checkout/payment/get-order-payment-actions.js
@@ -140,7 +140,7 @@ define([
             // ReCaptcha is enabled for placing orders, so trigger the recaptcha flow
             if (recaptchaRegistry.triggers && recaptchaRegistry.triggers.hasOwnProperty(reCaptchaId)) {
                 var recaptchaDeferred = $.Deferred();
-                if (isInvisibleCaptcha(reCaptchaId) && recaptchaRegistry.tokens.hasOwnProperty(reCaptchaId)) {
+                if (recaptchaRegistry.tokens.hasOwnProperty(reCaptchaId)) {
                     delete recaptchaRegistry.tokens[reCaptchaId];
                 }
                 recaptchaRegistry.addListener(reCaptchaId, function (token) {

--- a/view/frontend/web/js/action/checkout/payment/get-order-payment-actions.js
+++ b/view/frontend/web/js/action/checkout/payment/get-order-payment-actions.js
@@ -95,15 +95,19 @@ define([
         });
     }
 
+    const isInvisibleCaptcha = function (reCaptchaId) {
+        return recaptchaRegistry._isInvisibleType &&
+            recaptchaRegistry._isInvisibleType.hasOwnProperty(reCaptchaId) &&
+            recaptchaRegistry._isInvisibleType[reCaptchaId] === true;
+    }
+
     const removeReCaptchaListener = function (reCaptchaId) {
         // Old version of Magento Security Package does not have _isInvisibleType property
         if (!recaptchaRegistry._isInvisibleType) {
             return;
         }
         // Do not remove it for invisible reCaptcha
-        if (recaptchaRegistry._isInvisibleType.hasOwnProperty('recaptcha-checkout-place-order') &&
-            recaptchaRegistry._isInvisibleType['recaptcha-checkout-place-order'] === true
-        ) {
+        if (isInvisibleCaptcha(reCaptchaId)) {
             return;
         }
         recaptchaRegistry.removeListener(reCaptchaId)
@@ -124,10 +128,21 @@ define([
                 return getOrderPaymentActions(serviceUrl, {}, messageContainer);
             }
 
-            const reCaptchaId = 'recaptcha-checkout-place-order';
+            var reCaptchaId = 'recaptcha-checkout-place-order';
+            /*
+             * From version 1.1.6 of Magento Security Package, there are multiple recaptcha instances on the page,
+             * so we need to find the active one for placing an order.
+             */
+            var $activeReCaptcha = $('.recaptcha-checkout-place-order:visible .g-recaptcha');
+            if ($activeReCaptcha.length > 0) {
+                reCaptchaId = $activeReCaptcha.last().attr('id');
+            }
             // ReCaptcha is enabled for placing orders, so trigger the recaptcha flow
             if (recaptchaRegistry.triggers && recaptchaRegistry.triggers.hasOwnProperty(reCaptchaId)) {
                 var recaptchaDeferred = $.Deferred();
+                if (isInvisibleCaptcha(reCaptchaId) && recaptchaRegistry.tokens.hasOwnProperty(reCaptchaId)) {
+                    delete recaptchaRegistry.tokens[reCaptchaId];
+                }
                 recaptchaRegistry.addListener(reCaptchaId, function (token) {
                     //Add reCaptcha value to rvvup place-order request
                     getOrderPaymentActions(serviceUrl, {'X-ReCaptcha': token}, messageContainer)

--- a/view/frontend/web/js/action/checkout/payment/get-order-payment-actions.js
+++ b/view/frontend/web/js/action/checkout/payment/get-order-payment-actions.js
@@ -96,17 +96,17 @@ define([
     }
 
     const isInvisibleCaptcha = function (reCaptchaId) {
+        if (!recaptchaRegistry._isInvisibleType) {
+            // Old version of Magento Security Package does not have _isInvisibleType property, so we assume it was.
+            return true;
+        }
         return recaptchaRegistry._isInvisibleType &&
             recaptchaRegistry._isInvisibleType.hasOwnProperty(reCaptchaId) &&
             recaptchaRegistry._isInvisibleType[reCaptchaId] === true;
     }
 
     const removeReCaptchaListener = function (reCaptchaId) {
-        // Old version of Magento Security Package does not have _isInvisibleType property
-        if (!recaptchaRegistry._isInvisibleType) {
-            return;
-        }
-        // Do not remove it for invisible reCaptcha
+        // Do not remove the listener for invisible reCaptcha
         if (isInvisibleCaptcha(reCaptchaId)) {
             return;
         }

--- a/view/frontend/web/js/action/checkout/payment/get-order-payment-actions.js
+++ b/view/frontend/web/js/action/checkout/payment/get-order-payment-actions.js
@@ -110,7 +110,7 @@ define([
         if (isInvisibleCaptcha(reCaptchaId)) {
             return;
         }
-        recaptchaRegistry.removeListener(reCaptchaId)
+        recaptchaRegistry.removeListener(reCaptchaId);
     }
         /**
          * API request to get Order Payment Actions for Rvvup Payments.


### PR DESCRIPTION
In Magento Security Package 1.1.6 or higher
(https://github.com/magento/security-package/tree/1.1.6) the store has multiple recaptchas per payment method instead of one per checkout page on placing an order.