### PR TITLE
Write Card Metadata on order creation in magento

### DIFF
--- a/Service/Result.php
+++ b/Service/Result.php
@@ -147,7 +147,7 @@ class Result
             $payment = $order->getPayment();
             $dashboardUrl = $rvvupData['dashboardUrl'] ?? '';
             $payment->setAdditionalInformation(Method::DASHBOARD_URL, $dashboardUrl);
-            $this->cardMetaService->process($rvvupData, $order);
+            $this->cardMetaService->process($rvvupData['payments'][0], $order);
             $this->paymentResource->save($payment);
 
             if (get_class($processor) == Cancel::class) {

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -536,7 +536,7 @@
         </arguments>
     </type>
 
-    <type name="Rvvup\Payments\Observer\Model\ProcessOrder\CardsMetadata">
+    <type name="Rvvup\Payments\Service\Card\CardMetaService">
         <arguments>
             <argument name="logger" xsi:type="object">Rvvup\Payments\Model\Logger</argument>
         </arguments>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -19,9 +19,6 @@
         <observer name="Rvvup_Payments::Model\ProcessOrder\Complete\EmailSenderObserver"
                   instance="Rvvup\Payments\Observer\Model\ProcessOrder\EmailSenderObserver"
                   shared="false" />
-        <observer name="Rvvup_Payments::Model\ProcessOrder\Complete\CardsMetadata"
-                  instance="Rvvup\Payments\Observer\Model\ProcessOrder\CardsMetadata"
-                  shared="false" />
     </event>
 
     <event name="rvvup_payments_process_order_processing_after">


### PR DESCRIPTION
Previously was executed on complete listener, this ensures the data is actually present on authorization vs completion and also ensures the data is available on manual capture.