### PR TITLE
Force user to confirm shipping address when shipping method is not selected but address is prefilled

### DIFF
--- a/src/Service/Express/ExpressPaymentRequestMapper.php
+++ b/src/Service/Express/ExpressPaymentRequestMapper.php
@@ -29,6 +29,8 @@ class ExpressPaymentRequestMapper
      */
     public function map(Quote $quote): array
     {
+        $quote->setTotalsCollectedFlag(false);
+        $quote->collectTotals();
         $total = $quote->getGrandTotal();
         $result = [
             'methodOptions' => [


### PR DESCRIPTION
Also ensures totals are collected before mapping for express payments