### PR TITLE
[Launchpad Test] PAY-81: Apple Pay express checkout on PDP

### DIFF
--- a/src/Controller/Checkout/CreateOnDemand.php
+++ b/src/Controller/Checkout/CreateOnDemand.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rvvup\Payments\Controller\Checkout;
+
+use Exception;
+use InvalidArgumentException;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\CsrfAwareActionInterface;
+use Magento\Framework\App\Request\InvalidRequestException;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\Result\Json;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Data\Form\FormKey\Validator;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
+use Rvvup\Api\Model\ApplicationSource;
+use Rvvup\Api\Model\CheckoutCreateInput;
+use Rvvup\Payments\Service\ApiProvider;
+
+/**
+ * Creates a Rvvup checkout on demand (AJAX endpoint for PDP Apple Pay express checkout).
+ *
+ * Returns { success: true, data: { token, id } } on success.
+ */
+class CreateOnDemand implements HttpPostActionInterface, CsrfAwareActionInterface
+{
+    public const PATH = 'rvvup/checkout/createOnDemand';
+
+    /** @var RequestInterface */
+    private $request;
+
+    /** @var ResultFactory */
+    private $resultFactory;
+
+    /** @var Validator */
+    private $formKeyValidator;
+
+    /** @var SerializerInterface */
+    private $serializer;
+
+    /** @var ApiProvider */
+    private $apiProvider;
+
+    /** @var StoreManagerInterface */
+    private $storeManager;
+
+    /** @var LoggerInterface */
+    private $logger;
+
+    /** @var array|null */
+    private $requestBody;
+
+    public function __construct(
+        RequestInterface $request,
+        ResultFactory $resultFactory,
+        Validator $formKeyValidator,
+        SerializerInterface $serializer,
+        ApiProvider $apiProvider,
+        StoreManagerInterface $storeManager,
+        LoggerInterface $logger
+    ) {
+        $this->request = $request;
+        $this->resultFactory = $resultFactory;
+        $this->formKeyValidator = $formKeyValidator;
+        $this->serializer = $serializer;
+        $this->apiProvider = $apiProvider;
+        $this->storeManager = $storeManager;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @return Json
+     */
+    public function execute()
+    {
+        if (!$this->request->isPost() || !$this->request->isAjax()) {
+            return $this->returnErrorResponse('Invalid request');
+        }
+
+        try {
+            $storeId = (string) $this->storeManager->getStore()->getId();
+            $checkoutInput = (new CheckoutCreateInput())->setSource(ApplicationSource::MAGENTO_CHECKOUT);
+
+            try {
+                $checkoutInput->setMetadata([
+                    "domain" => $this->storeManager->getStore()->getBaseUrl(UrlInterface::URL_TYPE_WEB, true)
+                ]);
+            } catch (Exception $e) {
+                $this->logger->error('Ignoring error getting base url: ' . $e->getMessage());
+            }
+
+            $result = $this->apiProvider->getSdk($storeId)->checkouts()->create($checkoutInput, null);
+
+            if (!$result->getId() || !$result->getToken()) {
+                return $this->returnErrorResponse('Failed to create checkout');
+            }
+
+            /** @var Json $response */
+            $response = $this->resultFactory->create(ResultFactory::TYPE_JSON);
+            $response->setHttpResponseCode(200);
+            $response->setData([
+                'success' => true,
+                'data' => [
+                    'token' => $result->getToken(),
+                    'id' => $result->getId(),
+                ]
+            ]);
+
+            return $response;
+        } catch (Exception $e) {
+            $this->logger->error('Error creating on-demand checkout: ' . $e->getMessage());
+            return $this->returnErrorResponse('Failed to create checkout');
+        }
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return InvalidRequestException|null
+     */
+    public function createCsrfValidationException(RequestInterface $request): ?InvalidRequestException
+    {
+        return null;
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return bool|null
+     */
+    public function validateForCsrf(RequestInterface $request): ?bool
+    {
+        $requestBody = $this->getRequestBody();
+        $request->setParam('form_key', $requestBody['form_key'] ?? null);
+
+        return $this->formKeyValidator->validate($request);
+    }
+
+    /**
+     * @return array|null
+     */
+    private function getRequestBody(): ?array
+    {
+        if (is_array($this->requestBody)) {
+            return $this->requestBody;
+        }
+
+        try {
+            $this->requestBody = $this->serializer->unserialize($this->request->getContent());
+        } catch (InvalidArgumentException $ex) {
+            $this->logger->error('Failed to decode JSON request with message: ' . $ex->getMessage());
+            $this->requestBody = null;
+        }
+
+        return $this->requestBody;
+    }
+
+    /**
+     * @param string $message
+     * @return Json
+     */
+    private function returnErrorResponse(string $message): Json
+    {
+        /** @var Json $result */
+        $result = $this->resultFactory->create(ResultFactory::TYPE_JSON);
+        $result->setHttpResponseCode(200);
+        $result->setData([
+            'success' => false,
+            'error_message' => $message
+        ]);
+
+        return $result;
+    }
+}

--- a/src/ViewModel/ApplePayPdp.php
+++ b/src/ViewModel/ApplePayPdp.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rvvup\Payments\ViewModel;
+
+use Exception;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
+use Rvvup\Payments\Api\PaymentMethodsSettingsGetInterface;
+use Rvvup\Payments\Model\ConfigInterface;
+
+/**
+ * ViewModel for Apple Pay express checkout on product pages.
+ */
+class ApplePayPdp implements ArgumentInterface
+{
+    /** @var ConfigInterface */
+    private $config;
+
+    /** @var PaymentMethodsSettingsGetInterface */
+    private $paymentMethodsSettingsGet;
+
+    /** @var StoreManagerInterface */
+    private $storeManager;
+
+    /** @var LoggerInterface */
+    private $logger;
+
+    /** @var array|null */
+    private $settings;
+
+    public function __construct(
+        ConfigInterface $config,
+        PaymentMethodsSettingsGetInterface $paymentMethodsSettingsGet,
+        StoreManagerInterface $storeManager,
+        LoggerInterface $logger
+    ) {
+        $this->config = $config;
+        $this->paymentMethodsSettingsGet = $paymentMethodsSettingsGet;
+        $this->storeManager = $storeManager;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Check if Apple Pay express checkout is available on PDP.
+     *
+     * @return bool
+     */
+    public function isAvailable(): bool
+    {
+        if (!$this->config->isActive()) {
+            return false;
+        }
+
+        $settings = $this->getApplePaySettings();
+        if ($settings === null) {
+            return false;
+        }
+
+        $pdpExpressEnabled = $settings['pdp']['express']['enabled'] ?? false;
+
+        return (bool) $pdpExpressEnabled;
+    }
+
+    /**
+     * Check if the product type supports Apple Pay express checkout.
+     *
+     * @param ProductInterface $product
+     * @return bool
+     */
+    public function canUseForProductType(ProductInterface $product): bool
+    {
+        switch ($product->getTypeId()) {
+            case 'grouped':
+            case 'bundle':
+            case null:
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    /**
+     * @return array|null
+     */
+    private function getApplePaySettings(): ?array
+    {
+        if ($this->settings !== null) {
+            return $this->settings;
+        }
+
+        try {
+            $storeCurrency = $this->storeManager->getStore()->getCurrentCurrency()->getCode();
+            $allSettings = $this->paymentMethodsSettingsGet->execute('0', $storeCurrency);
+            $this->settings = $allSettings['rvvup_apple_pay'] ?? null;
+        } catch (Exception $e) {
+            $this->logger->error('Error getting Apple Pay settings: ' . $e->getMessage());
+            $this->settings = null;
+        }
+
+        return $this->settings;
+    }
+}

--- a/src/etc/frontend/di.xml
+++ b/src/etc/frontend/di.xml
@@ -71,7 +71,17 @@
             <argument name="logger" xsi:type="object">Rvvup\Payments\Model\Logger</argument>
         </arguments>
     </type>
+    <type name="Rvvup\Payments\Controller\Checkout\CreateOnDemand">
+        <arguments>
+            <argument name="logger" xsi:type="object">Rvvup\Payments\Model\Logger</argument>
+        </arguments>
+    </type>
     <!-- View Models -->
+    <type name="Rvvup\Payments\ViewModel\ApplePayPdp">
+        <arguments>
+            <argument name="logger" xsi:type="object">Rvvup\Payments\Model\Logger</argument>
+        </arguments>
+    </type>
     <type name="Rvvup\Payments\ViewModel\Clearpay">
         <arguments>
             <argument name="session" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>

--- a/src/view/frontend/layout/catalog_product_view.xml
+++ b/src/view/frontend/layout/catalog_product_view.xml
@@ -35,6 +35,18 @@
                    before="product.info">
             </block>
         </referenceContainer>
+        <!-- Apple Pay express checkout on PDP -->
+        <referenceBlock name="product.info.addtocart">
+            <block class="Magento\Catalog\Block\Product\View"
+                   name="rvvup_payments.product.catalog_product_view.apple_pay_express"
+                   template="Rvvup_Payments::product/view/apple-pay-express.phtml"
+                   ifconfig="payment/rvvup/active">
+                <arguments>
+                    <argument name="rvvup_payments_apple_pay_pdp_view_model"
+                              xsi:type="object">Rvvup\Payments\ViewModel\ApplePayPdp</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
         <!-- After add to cart -->
         <referenceBlock name="product.info.addtocart">
             <block class="Magento\Catalog\Block\Product\View"

--- a/src/view/frontend/templates/product/view/apple-pay-express.phtml
+++ b/src/view/frontend/templates/product/view/apple-pay-express.phtml
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Apple Pay express checkout button on product pages.
+ *
+ * @var \Magento\Catalog\Block\Product\View $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
+/** Magento 2.3.5 backward compatibility fix */
+if (!isset($escaper)) {
+    $escaper = $block;
+}
+
+/** @var \Rvvup\Payments\ViewModel\ApplePayPdp $applePayPdpViewModel */
+$applePayPdpViewModel = $block->getData('rvvup_payments_apple_pay_pdp_view_model');
+
+if ($applePayPdpViewModel === null || !$applePayPdpViewModel->isAvailable()) {
+    return;
+}
+
+$product = $block->getProduct();
+if ($product === null) {
+    return;
+}
+
+if (!$applePayPdpViewModel->canUseForProductType($product)) {
+    return;
+}
+
+if ((bool) $product->getRvvupRestricted()) {
+    return;
+}
+
+$initialPrice = number_format((float) $product->getFinalPrice(), 2, '.', '');
+$currencyCode = $product->getStore()->getCurrentCurrencyCode();
+?>
+
+<div id="rvvup-apple-pay-pdp-express-container" class="rvvup-apple-pay-pdp-express-container"></div>
+<script type="text/x-magento-init">
+    {
+        "#rvvup-apple-pay-pdp-express-container": {
+            "Rvvup_Payments/js/method/apple-pay/pdp-express-checkout": {
+                "containerId": "rvvup-apple-pay-pdp-express-container",
+                "initialPrice": "<?= $escaper->escapeHtmlAttr($initialPrice); ?>",
+                "currency": "<?= $escaper->escapeHtmlAttr($currencyCode); ?>"
+            }
+        }
+    }
+</script>

--- a/src/view/frontend/web/js/action/create-checkout-on-demand.js
+++ b/src/view/frontend/web/js/action/create-checkout-on-demand.js
@@ -1,0 +1,33 @@
+define([
+    'jquery',
+    'mage/url',
+    'mage/cookies'
+], function ($, url, cookies) {
+    'use strict';
+
+    /**
+     * Create a Rvvup checkout on demand via AJAX.
+     *
+     * @return {Object} jQuery Deferred resolving to { token, id }
+     */
+    return function () {
+        var payload = {
+            form_key: $.mage.cookies.get('form_key')
+        };
+
+        url.setBaseUrl(window.BASE_URL || '/');
+
+        return $.ajax({
+            url: url.build('rvvup/checkout/createOnDemand'),
+            type: 'POST',
+            data: JSON.stringify(payload),
+            contentType: 'application/json',
+            dataType: 'json'
+        }).then(function (response) {
+            if (response.success && response.data) {
+                return response.data;
+            }
+            return $.Deferred().reject(response.error_message || 'Failed to create checkout').promise();
+        });
+    };
+});

--- a/src/view/frontend/web/js/method/apple-pay/pdp-express-checkout.js
+++ b/src/view/frontend/web/js/method/apple-pay/pdp-express-checkout.js
@@ -1,0 +1,273 @@
+define([
+    'uiComponent',
+    'jquery',
+    'mage/translate',
+    'Rvvup_Payments/js/action/add-to-cart',
+    'Rvvup_Payments/js/action/create-cart',
+    'Rvvup_Payments/js/action/create-checkout-on-demand',
+    'Rvvup_Payments/js/action/empty-cart',
+    'Rvvup_Payments/js/action/set-session-message',
+    'Rvvup_Payments/js/helper/get-add-to-cart-payload',
+    'Rvvup_Payments/js/helper/get-current-quote-id',
+    'Rvvup_Payments/js/helper/get-pdp-form',
+    'Rvvup_Payments/js/helper/get-store-code',
+    'Rvvup_Payments/js/helper/is-logged-in',
+    'Rvvup_Payments/js/helper/validate-pdp-form',
+    'mage/storage',
+    'Magento_Checkout/js/model/url-builder',
+    'domReady!'
+], function (
+    Component,
+    $,
+    $t,
+    addToCart,
+    createCart,
+    createCheckoutOnDemand,
+    emptyCart,
+    setSessionMessage,
+    getAddToCartPayload,
+    getCurrentQuoteId,
+    getPdpForm,
+    getStoreCode,
+    isLoggedIn,
+    validatePdpForm,
+    storage,
+    checkoutUrlBuilder
+) {
+    'use strict';
+
+    return Component.extend({
+        defaults: {
+            containerId: null,
+            initialPrice: null,
+            currency: 'GBP',
+            expressCheckoutInstance: null,
+            cartId: null
+        },
+
+        /**
+         * Initialize the Apple Pay express checkout on PDP.
+         *
+         * @param {Object} config
+         */
+        initialize: function (config) {
+            this.containerId = config.containerId;
+            this.initialPrice = config.initialPrice;
+            this.currency = config.currency || 'GBP';
+
+            if (!this.containerId || !this.initialPrice) {
+                return this;
+            }
+
+            if (!window.rvvup_sdk) {
+                console.error('Rvvup SDK not loaded');
+                return this;
+            }
+
+            this.render();
+            return this;
+        },
+
+        /**
+         * Create and mount the express checkout Apple Pay button.
+         */
+        render: function () {
+            var self = this;
+            var containerEl = document.getElementById(self.containerId);
+
+            if (!containerEl) {
+                return;
+            }
+
+            var form = getPdpForm(containerEl);
+
+            window.rvvup_sdk.createExpressCheckout({
+                enabledPaymentMethods: ['APPLE_PAY'],
+                paymentRequest: {
+                    total: {
+                        amount: self.initialPrice.toString(),
+                        currency: self.currency
+                    }
+                }
+            }).then(function (expressCheckout) {
+                self.expressCheckoutInstance = expressCheckout;
+
+                expressCheckout.on('ready', function () {
+                    expressCheckout.mount({selector: '#' + self.containerId});
+                });
+
+                expressCheckout.on('beforePaymentAuth', function () {
+                    return self.handleBeforePaymentAuth(form);
+                });
+
+                expressCheckout.on('paymentAuthorized', function () {
+                    self.handlePaymentCompleted();
+                });
+
+                expressCheckout.on('paymentCaptured', function () {
+                    self.handlePaymentCompleted();
+                });
+
+                expressCheckout.on('paymentFailed', function (data) {
+                    $('body').trigger('processStop');
+                    setSessionMessage($t('Payment failed: ' + (data.reason || 'Unknown error')), 'error');
+                });
+
+            }).catch(function (error) {
+                console.error('Error creating Apple Pay express checkout:', error);
+            });
+
+            // Listen for price updates (configurable products, qty changes, etc.)
+            $(document).on('priceUpdated', '.product-info-main .price-box', function (event, data) {
+                var amount = self.getFinalAmount(data);
+                if (amount == null || !self.expressCheckoutInstance) {
+                    return;
+                }
+                self.expressCheckoutInstance.update({
+                    paymentRequest: {
+                        total: {
+                            currency: self.currency,
+                            amount: amount.toString()
+                        }
+                    }
+                });
+            });
+        },
+
+        /**
+         * Handle the beforePaymentAuth event:
+         * 1. Validate the PDP form
+         * 2. Create or empty cart
+         * 3. Add product to cart
+         * 4. Create Rvvup checkout on demand
+         * 5. Create payment session
+         * 6. Return { checkoutSessionKey, paymentSessionId }
+         *
+         * @param {Element|null} form
+         * @return {Promise}
+         */
+        handleBeforePaymentAuth: function (form) {
+            var self = this;
+
+            // Validate the PDP form (checks required options, qty, etc.)
+            if (form && !validatePdpForm(form)) {
+                return Promise.resolve(false);
+            }
+
+            $('body').trigger('processStart');
+
+            return self.prepareCart()
+                .then(function (cartId) {
+                    self.cartId = cartId;
+
+                    if (!form) {
+                        return $.Deferred().reject('Product form not found').promise();
+                    }
+
+                    // Add product to the cart
+                    return addToCart(cartId, getAddToCartPayload(form, cartId));
+                })
+                .then(function () {
+                    // Create Rvvup checkout on demand
+                    return createCheckoutOnDemand();
+                })
+                .then(function (checkoutData) {
+                    // Create payment session using the checkout
+                    return self.createPaymentSession(self.cartId, checkoutData.id)
+                        .then(function (sessionData) {
+                            $('body').trigger('processStop');
+                            return {
+                                checkoutSessionKey: checkoutData.token,
+                                paymentSessionId: sessionData.payment_session_id
+                            };
+                        });
+                })
+                .catch(function (error) {
+                    $('body').trigger('processStop');
+                    console.error('Error in beforePaymentAuth:', error);
+                    setSessionMessage($t('Something went wrong while processing your payment'), 'error');
+                    return false;
+                });
+        },
+
+        /**
+         * Create or empty the cart, returning a cart ID.
+         *
+         * @return {Object} jQuery Deferred resolving to cartId
+         */
+        prepareCart: function () {
+            var currentQuoteId = getCurrentQuoteId();
+
+            if (currentQuoteId === null) {
+                return createCart();
+            }
+
+            return emptyCart(currentQuoteId);
+        },
+
+        /**
+         * Create a payment session for the given cart and checkout.
+         *
+         * Uses the existing webapi endpoint: /V1/rvvup/payments/:cartId/create-payment-session/:checkoutId
+         *
+         * @param {string} cartId
+         * @param {string} checkoutId
+         * @return {Object} jQuery Deferred resolving to { payment_session_id, redirect_url }
+         */
+        createPaymentSession: function (cartId, checkoutId) {
+            checkoutUrlBuilder.storeCode = getStoreCode();
+
+            var serviceUrl;
+            var payload = {
+                cartId: cartId,
+                paymentMethod: {
+                    method: 'rvvup_apple_pay'
+                },
+                billingAddress: {}
+            };
+
+            if (!isLoggedIn()) {
+                serviceUrl = checkoutUrlBuilder.createUrl(
+                    '/rvvup/payments/:cartId/create-payment-session/:checkoutId',
+                    {cartId: cartId, checkoutId: checkoutId}
+                );
+                payload.email = 'pending@applepay.express';
+            } else {
+                serviceUrl = checkoutUrlBuilder.createUrl(
+                    '/rvvup/payments/mine/:cartId/create-payment-session/:checkoutId',
+                    {cartId: cartId, checkoutId: checkoutId}
+                );
+            }
+
+            return storage.post(
+                serviceUrl,
+                JSON.stringify(payload),
+                true,
+                'application/json',
+                {}
+            );
+        },
+
+        /**
+         * Handle successful payment (authorized or captured) - redirect to success page.
+         */
+        handlePaymentCompleted: function () {
+            $('body').trigger('processStart');
+            window.location.href = window.checkout
+                ? window.checkout.baseUrl + 'checkout/onepage/success/'
+                : '/checkout/onepage/success/';
+        },
+
+        /**
+         * Extract the final amount from a priceUpdated event data payload.
+         *
+         * @param {Object} data
+         * @return {number|null}
+         */
+        getFinalAmount: function (data) {
+            return (data && data.finalPrice && data.finalPrice.amount)
+                || (data && data.prices && data.prices.finalPrice && data.prices.finalPrice.amount)
+                || null;
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Adds Apple Pay as an express payment method on Magento product pages (PDP) using the browser-sdk's deferred `checkoutSessionKey` pattern.

### Changes
- **`Controller/Checkout/CreateOnDemand.php`** (new): AJAX endpoint to create Rvvup checkout on demand
- **`ViewModel/ApplePayPdp.php`** (new): ViewModel checking PDP Apple Pay eligibility
- **`view/frontend/templates/product/view/apple-pay-express.phtml`** (new): PDP container template
- **`view/frontend/web/js/action/create-checkout-on-demand.js`** (new): RequireJS module for checkout creation
- **`view/frontend/web/js/method/apple-pay/pdp-express-checkout.js`** (new): PDP express checkout component
- **`view/frontend/layout/catalog_product_view.xml`**: Layout XML for PDP block
- **`etc/frontend/di.xml`**: DI config for new classes

### Flow
1. Product page loads -> SDK init with `publishableKey` only
2. Apple Pay button renders via `createExpressCheckout()`
3. User clicks -> `beforePaymentAuth` -> creates cart, adds product, creates Rvvup checkout on demand
4. Payment session created with checkout ID
5. Returns `{ checkoutSessionKey, paymentSessionId }` to SDK
6. Apple Pay sheet opens, payment completes -> redirect to success

Generated with [Claude Code](https://claude.com/claude-code) via pos-launchpad