### PR TITLE
Replace wait-for-api action with shell script

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -44,13 +44,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Wait for Magento Store
-        uses: mydea/action-wait-for-api@v2.0.0
-        with:
-          url: http://local.dev.rvvuptech.com/magento_version
-          method: GET
-          expected-status: "200"
-          timeout: "500"
-          interval: "5"
+        run: bash scripts/helpers/wait-for-server-startup.sh
 
       - name: Run Playwright tests
         run: TEST_BASE_URL=http://localhost npx playwright test

--- a/scripts/helpers/wait-for-server-startup.sh
+++ b/scripts/helpers/wait-for-server-startup.sh
@@ -29,7 +29,7 @@ while true; do
         exit 1
     fi
 
-    http_status=$(curl -o /dev/null -s -w "%{http_code}\n" -I "$URL" || echo "000")
+    http_status=$(curl -o /dev/null -s -w "%{http_code}" -I "$URL" || true)
 
     if [ "$http_status" = "200" ]; then
         print_green "\r✔ Server Ready. Time taken: ${elapsed} seconds."

--- a/scripts/helpers/wait-for-server-startup.sh
+++ b/scripts/helpers/wait-for-server-startup.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
+set -euo pipefail
+
+URL="${1:-http://local.dev.rvvuptech.com/magento_version}"
+TIMEOUT="${2:-500}"
+
 start=$(date +%s)
 attempt=1
 spinner="⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
 print_red() {
-    echo -e "\033[31m$1\033[0m" # Red text
+    echo -e "\033[31m$1\033[0m"
 }
 
 print_green() {
-    echo -e "\033[32m$1\033[0m" # Green text
+    echo -e "\033[32m$1\033[0m"
 }
 
 pretty_loader() {
@@ -17,18 +22,25 @@ pretty_loader() {
 }
 
 while true; do
-    http_status=$(curl -o /dev/null -s -w "%{http_code}\n" -I "http://local.dev.rvvuptech.com/magento_version")
+    elapsed=$(( $(date +%s) - start ))
 
-    if [ "$http_status" -eq 200 ]; then
-        print_green "\r✔ Server Ready. Time taken: $(($(date +%s) - start)) seconds."
-        break
+    if [ "$elapsed" -ge "$TIMEOUT" ]; then
+        print_red "\r✖ TIMEOUT! Server did not respond within ${TIMEOUT} seconds."
+        exit 1
     fi
 
-    if [ "$http_status" -gt 299 ]; then
-          print_red "\r✖ ERROR! Server responded with $http_status. Time taken: $(($(date +%s) - start)) seconds."
-          break;
+    http_status=$(curl -o /dev/null -s -w "%{http_code}\n" -I "$URL" || echo "000")
+
+    if [ "$http_status" = "200" ]; then
+        print_green "\r✔ Server Ready. Time taken: ${elapsed} seconds."
+        break
+    elif [ "$http_status" = "000" ]; then
+        echo -ne "\r$(pretty_loader) $(pretty_loader) \033[90mWaiting for server to be up (Might take a couple of minutes). Current Status: $http_status / Time taken: ${elapsed} seconds.\033[0m"
+    elif [ "$http_status" -gt 299 ]; then
+        print_red "\r✖ ERROR! Server responded with $http_status. Time taken: ${elapsed} seconds."
+        exit 1
     else
-          echo -ne "\r$(pretty_loader) $(pretty_loader) \033[90mWaiting for server to be up (Might take a couple of minutes). Current Status: $http_status / Time taken: $(($(date +%s) - start)) seconds.\033[0m"
+        echo -ne "\r$(pretty_loader) $(pretty_loader) \033[90mWaiting for server to be up (Might take a couple of minutes). Current Status: $http_status / Time taken: ${elapsed} seconds.\033[0m"
     fi
 
     attempt=$((attempt + 1))


### PR DESCRIPTION
## Summary
- Removes the `mydea/action-wait-for-api@v2.0.0` GitHub Action which requires Node 20 (incompatible with current GitHub workers requiring Node 24)
- Replaces it with a direct call to the existing `scripts/helpers/wait-for-server-startup.sh`
- Updated the script to accept URL and timeout as arguments (with defaults matching prior config), add a hard timeout with `exit 1`, and handle curl connection failures (exit code 56) gracefully by continuing to poll