### PR TITLE
SUPPORT-148: Fix Apple Pay shipping discount calculation

### DIFF
--- a/src/Model/OrderDataBuilder.php
+++ b/src/Model/OrderDataBuilder.php
@@ -191,7 +191,10 @@ class OrderDataBuilder
                 "currency" => $quote->getQuoteCurrencyCode(),
             ],
             "discountTotal" => [
-                "amount" => $this->toCurrency($quote->getBaseSubtotal() - $quote->getBaseSubtotalWithDiscount()),
+                "amount" => $this->toCurrency(
+                    ($quote->getBaseSubtotal() - $quote->getBaseSubtotalWithDiscount())
+                    + (float)($quote->getShippingAddress() ? $quote->getShippingAddress()->getShippingDiscountAmount() : 0.0)
+                ),
                 "currency" => $quote->getQuoteCurrencyCode(),
             ],
             "shippingTotal" => [

--- a/src/Model/Shipping/ShippingMethod.php
+++ b/src/Model/Shipping/ShippingMethod.php
@@ -24,13 +24,14 @@ class ShippingMethod
     /**
      * @param ShippingMethodInterface $shippingMethod
      * @param string $currency
+     * @param float $shippingDiscount Shipping discount amount to subtract from the gross price (default 0.0)
      */
-    public function __construct(ShippingMethodInterface $shippingMethod, string $currency)
+    public function __construct(ShippingMethodInterface $shippingMethod, string $currency, float $shippingDiscount = 0.0)
     {
         // Magento sets the shipping method using this format: `carrier_code`_`method_code`.
         $this->id = $shippingMethod->getCarrierCode() . '_' . $shippingMethod->getMethodCode();
         $this->label = $this->generateLabel($shippingMethod);
-        $this->amount = number_format($shippingMethod->getPriceInclTax(), 2, '.', '');
+        $this->amount = number_format(max(0.0, (float)$shippingMethod->getPriceInclTax() - $shippingDiscount), 2, '.', '');
         $this->currency = $currency;
     }
 

--- a/src/Service/Shipping/ShippingMethodService.php
+++ b/src/Service/Shipping/ShippingMethodService.php
@@ -141,13 +141,23 @@ class ShippingMethodService
         if (empty($shippingMethods)) {
             return [];
         }
+
+        // Collect totals so shipping discount amounts are populated on the shipping address before we read them.
+        $quote->setTotalsCollectedFlag(false);
+        $quote->collectTotals();
+        $shippingDiscount = (float)$quote->getShippingAddress()->getShippingDiscountAmount();
+
         $returnedShippingMethods = [];
         foreach ($shippingMethods as $shippingMethod) {
             if ($shippingMethod->getErrorMessage()) {
                 continue;
             }
 
-            $returnedShippingMethods[] = new ShippingMethod($shippingMethod, $quote->getQuoteCurrencyCode());
+            $returnedShippingMethods[] = new ShippingMethod(
+                $shippingMethod,
+                $quote->getQuoteCurrencyCode(),
+                $shippingDiscount
+            );
         }
         return $returnedShippingMethods;
     }


### PR DESCRIPTION
## Summary

- Pass the quote's shipping discount amount through to `ShippingMethod` so the Apple Pay payment sheet displays the post-discount shipping price rather than the pre-discount estimated price (`ShippingMethodService`, `ShippingMethod`)
- Include the shipping discount in `discountTotal` in the order payload sent to the Rvvup API so the breakdown correctly reflects where the discount is applied (`OrderDataBuilder`)

## Root cause

When building the shipping methods list for the Apple Pay sheet, `ShippingMethod` used `getPriceInclTax()` from Magento's estimation API, which returns the undiscounted shipping price. The order `total` field was correctly computed from `getGrandTotal()` (post-discount), creating an inconsistency that Apple Pay could not reconcile — resulting in an incorrect total being shown to the customer.

Standard card checkout was unaffected because it submits a fully-collected quote where `getShippingAmount()` already reflects the post-discount amount.

## Changes

- `src/Model/Shipping/ShippingMethod.php` — constructor accepts optional `$shippingDiscount` float (default `0.0`) and subtracts it from `getPriceInclTax()`, floored at zero
- `src/Service/Shipping/ShippingMethodService.php` — calls `collectTotals()` after estimation to populate discount amounts on the shipping address, then reads `getShippingDiscountAmount()` and passes it to `ShippingMethod`
- `src/Model/OrderDataBuilder.php` — adds `getShippingDiscountAmount()` from the shipping address to `discountTotal`

## Test plan

- [ ] Configure a Magento basket with a shipping charge and a matching shipping discount (netting to zero)
- [ ] Confirm Apple Pay sheet shows the correct total (zero shipping, correct grand total)
- [ ] Confirm standard card checkout still shows the correct total
- [ ] Confirm basket with no shipping discount is unaffected (discount defaults to 0.0, no change in behaviour)
- [ ] Confirm virtual order (no shipping) is unaffected

Relates to: https://zopapos.atlassian.net/browse/SUPPORT-148

🤖 Generated with [Claude Code](https://claude.com/claude-code)