### PR TITLE
Fix Apple Pay shipping discount not reflected in payment sheet (SUPPORT-148)

### DIFF
--- a/Test/Unit/Model/Shipping/ShippingMethodTest.php
+++ b/Test/Unit/Model/Shipping/ShippingMethodTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rvvup\Payments\Test\Unit\Model\Shipping;
+
+use Magento\Quote\Api\Data\ShippingMethodInterface;
+use PHPUnit\Framework\TestCase;
+use Rvvup\Payments\Model\Shipping\ShippingMethod;
+
+class ShippingMethodTest extends TestCase
+{
+    private function makeShippingMethodMock(float $priceInclTax): ShippingMethodInterface
+    {
+        $mock = $this->createMock(ShippingMethodInterface::class);
+        $mock->method('getCarrierCode')->willReturn('flatrate');
+        $mock->method('getMethodCode')->willReturn('flatrate');
+        $mock->method('getCarrierTitle')->willReturn('Flat Rate');
+        $mock->method('getMethodTitle')->willReturn('Fixed');
+        $mock->method('getPriceInclTax')->willReturn($priceInclTax);
+        return $mock;
+    }
+
+    public function testAmountWithNoShippingDiscount(): void
+    {
+        $shippingMethod = new ShippingMethod(
+            $this->makeShippingMethodMock(10.00),
+            'GBP',
+            0.00
+        );
+
+        $this->assertSame('10.00', $shippingMethod->getAmount());
+    }
+
+    public function testAmountIsReducedByShippingDiscount(): void
+    {
+        // Shipping costs £10, free shipping promo applied - net should be £0
+        $shippingMethod = new ShippingMethod(
+            $this->makeShippingMethodMock(10.00),
+            'GBP',
+            10.00
+        );
+
+        $this->assertSame('0.00', $shippingMethod->getAmount());
+    }
+
+    public function testAmountDoesNotGoBelowZero(): void
+    {
+        // Discount larger than shipping (edge case)
+        $shippingMethod = new ShippingMethod(
+            $this->makeShippingMethodMock(5.00),
+            'GBP',
+            10.00
+        );
+
+        $this->assertSame('0.00', $shippingMethod->getAmount());
+    }
+
+    public function testPartialShippingDiscount(): void
+    {
+        // £10 shipping, £3 discount -> £7 net
+        $shippingMethod = new ShippingMethod(
+            $this->makeShippingMethodMock(10.00),
+            'GBP',
+            3.00
+        );
+
+        $this->assertSame('7.00', $shippingMethod->getAmount());
+    }
+}

--- a/Test/Unit/Service/Shipping/ShippingMethodServiceTest.php
+++ b/Test/Unit/Service/Shipping/ShippingMethodServiceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rvvup\Payments\Test\Unit\Service\Shipping;
+
+use Magento\Quote\Api\Data\ShippingMethodInterface;
+use PHPUnit\Framework\TestCase;
+use Rvvup\Payments\Model\Shipping\ShippingMethod;
+
+/**
+ * Verifies the shipping discount is passed through to ShippingMethod correctly,
+ * matching the call pattern in ShippingMethodService::getAvailableShippingMethods after the fix.
+ * ShippingMethodService itself depends on Checkout module classes not available in this environment.
+ */
+class ShippingMethodServiceTest extends TestCase
+{
+    private function makeShippingMethodMock(float $priceInclTax): ShippingMethodInterface
+    {
+        $mock = $this->createMock(ShippingMethodInterface::class);
+        $mock->method('getCarrierCode')->willReturn('flatrate');
+        $mock->method('getMethodCode')->willReturn('flatrate');
+        $mock->method('getCarrierTitle')->willReturn('Flat Rate');
+        $mock->method('getMethodTitle')->willReturn('Fixed');
+        $mock->method('getPriceInclTax')->willReturn($priceInclTax);
+        return $mock;
+    }
+
+    private function buildShippingMethod(float $priceInclTax, float $discount): ShippingMethod
+    {
+        return new ShippingMethod($this->makeShippingMethodMock($priceInclTax), 'GBP', $discount);
+    }
+
+    public function testAmountWithNoDiscount(): void
+    {
+        $this->assertSame('10.00', $this->buildShippingMethod(10.00, 0.00)->getAmount());
+    }
+
+    public function testAmountReflectsFreeShippingDiscount(): void
+    {
+        // estimateByExtendedAddress returns GBP10 pre-discount,
+        // but a free shipping promo means Apple Pay sheet should show GBP0.
+        $this->assertSame('0.00', $this->buildShippingMethod(10.00, 10.00)->getAmount(),
+            'Apple Pay sheet should show post-discount shipping amount, not pre-discount');
+    }
+
+    public function testAmountWithPartialDiscount(): void
+    {
+        $this->assertSame('7.00', $this->buildShippingMethod(10.00, 3.00)->getAmount());
+    }
+}

--- a/src/Model/Shipping/ShippingMethod.php
+++ b/src/Model/Shipping/ShippingMethod.php
@@ -24,13 +24,14 @@ class ShippingMethod
     /**
      * @param ShippingMethodInterface $shippingMethod
      * @param string $currency
+     * @param float $shippingDiscount Shipping discount amount from the quote address (post-collectTotals)
      */
-    public function __construct(ShippingMethodInterface $shippingMethod, string $currency)
+    public function __construct(ShippingMethodInterface $shippingMethod, string $currency, float $shippingDiscount = 0.0)
     {
         // Magento sets the shipping method using this format: `carrier_code`_`method_code`.
         $this->id = $shippingMethod->getCarrierCode() . '_' . $shippingMethod->getMethodCode();
         $this->label = $this->generateLabel($shippingMethod);
-        $this->amount = number_format($shippingMethod->getPriceInclTax(), 2, '.', '');
+        $this->amount = number_format(max(0.0, $shippingMethod->getPriceInclTax() - $shippingDiscount), 2, '.', '');
         $this->currency = $currency;
     }
 

--- a/src/Service/Shipping/ShippingMethodService.php
+++ b/src/Service/Shipping/ShippingMethodService.php
@@ -134,20 +134,32 @@ class ShippingMethodService
      */
     public function getAvailableShippingMethods(Quote $quote): array
     {
+        $shippingAddress = $quote->getShippingAddress();
         $shippingMethods = $this->shipmentEstimation->estimateByExtendedAddress(
             $quote->getId(),
-            $quote->getShippingAddress()
+            $shippingAddress
         );
         if (empty($shippingMethods)) {
             return [];
         }
+
+        // estimateByExtendedAddress returns pre-discount shipping prices. Read the shipping discount
+        // from the address (populated by collectTotals) so the Apple Pay sheet shows the correct net amount.
+        $quote->setTotalsCollectedFlag(false);
+        $quote->collectTotals();
+        $shippingDiscount = (float) $shippingAddress->getShippingDiscountAmount();
+
         $returnedShippingMethods = [];
         foreach ($shippingMethods as $shippingMethod) {
             if ($shippingMethod->getErrorMessage()) {
                 continue;
             }
 
-            $returnedShippingMethods[] = new ShippingMethod($shippingMethod, $quote->getQuoteCurrencyCode());
+            $returnedShippingMethods[] = new ShippingMethod(
+                $shippingMethod,
+                $quote->getQuoteCurrencyCode(),
+                $shippingDiscount
+            );
         }
         return $returnedShippingMethods;
     }


### PR DESCRIPTION
## Summary

- `ShippingMethodService::getAvailableShippingMethods` now calls `collectTotals()` after estimating shipping rates, reads `getShippingDiscountAmount()` from the quote shipping address, and passes it to each `ShippingMethod` instance
- `ShippingMethod` constructor accepts a new optional `$shippingDiscount` parameter (default `0.0`) and subtracts it from `getPriceInclTax()` when building the amount shown in the Apple Pay payment sheet, clamped to zero

## Problem

When a shipping discount promotion is active (e.g. free shipping rule), `estimateByExtendedAddress` returns the pre-discount shipping price. The Apple Pay sheet was built using this inflated amount, while the order `total` correctly reflected the post-discount grand total. Apple Pay could not reconcile the two, resulting in the wrong total being displayed to the customer and orders being charged at an incorrect amount.

Standard card checkout was unaffected as it uses `getShippingAmount()` on the fully-collected quote.

Reported in: https://zopapos.atlassian.net/browse/SUPPORT-148

## Test plan

- [ ] 7 new unit tests added covering: no discount, full free shipping discount, partial discount, and floor-at-zero edge case — all passing
- [ ] Full existing unit test suite unchanged (14 pre-existing fixture errors unrelated to this change)
- [ ] Manual validation: configure flat rate shipping + free shipping cart price rule, add item to cart, confirm Apple Pay sheet shows correct net shipping amount (£0.00 when fully discounted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)